### PR TITLE
bootstrap: stub crashReporterSetup.getGlobalSentry

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -69,6 +69,7 @@ const startCore = () => {
     },
     crashReporterSetup: {
       isInitialized: () => true,
+      getGlobalSentry: () => null,
       metadata: {}
     }
   });


### PR DESCRIPTION
stops meaningless terminal errors